### PR TITLE
cart no longer loads ordered items on login

### DIFF
--- a/client/components/SingleProduct.js
+++ b/client/components/SingleProduct.js
@@ -73,9 +73,6 @@ class SingleProduct extends Component {
               <div className="product-description">
                 {this.props.product.description}
               </div>
-//               {this.props.product.tags.map(tag => (
-//                 <div key={tag.id}>{tag.tagName}</div>
-//               ))}
               <button
                 className="btn btn-warning"
                 type="button"

--- a/client/components/SingleProduct.js
+++ b/client/components/SingleProduct.js
@@ -73,9 +73,9 @@ class SingleProduct extends Component {
               <div className="product-description">
                 {this.props.product.description}
               </div>
-              {this.props.product.tags.map(tag => (
-                <div key={tag.id}>{tag.tagName}</div>
-              ))}
+//               {this.props.product.tags.map(tag => (
+//                 <div key={tag.id}>{tag.tagName}</div>
+//               ))}
               <button
                 className="btn btn-warning"
                 type="button"

--- a/client/store/cart.js
+++ b/client/store/cart.js
@@ -55,7 +55,7 @@ export const eraseFromCart = id => (dispatch, getState) => {
   const item = cart.find(el => el.productId === id);
   const index = cart.indexOf(item);
   cart.splice(index, 1);
-  dispatch(removeProduct(cart));
+  dispatch(eraseProduct(cart));
 };
 
 export const getMyCart = () => async dispatch => {
@@ -102,6 +102,8 @@ export default function(state = [], action) {
     case ADD_PRODUCT:
       return action.cart;
     case REMOVE_PRODUCT:
+      return action.cart;
+    case ERASE_PRODUCT:
       return action.cart;
     case GET_CART:
       return action.cart;

--- a/server/api/carts.js
+++ b/server/api/carts.js
@@ -9,7 +9,9 @@ router.get('/', async (req, res, next) => {
       cart = req.session.cart;
     }
     if (req.user) {
-      const userCart = await Cart.findAll({ where: { userId: req.user.id } });
+      const userCart = await Cart.findAll({
+        where: { userId: req.user.id, orderId: null },
+      });
       userCart.forEach(item => {
         const existing = cart.find(thing => thing.productId === item.productId);
         if (existing) {
@@ -82,7 +84,7 @@ router.put('/', async (req, res, next) => {
             }
           }
         });
-        res.status(200);
+        res.status(200).end();
       });
     } else {
       res.sendStatus(200);


### PR DESCRIPTION
small edit to cart reducer to dispatch ERASE_ITEM instead of REMOVE_ITEM when 'delete' is clicked in cart

added back .end() to PUT /api/carts -- may have issues with tests

edited GET /api/carts so that only unordered items are added to cart on login (added "orderId: null" to the where condition)