### PR TITLE
don't load deleted items on login

### DIFF
--- a/client/store/cart.js
+++ b/client/store/cart.js
@@ -40,11 +40,7 @@ export const removeFromCart = id => (dispatch, getState) => {
   const cart = getState().cart.slice();
   const item = cart.find(el => el.productId === id);
   let currentQuantity = item.quantity;
-  if (currentQuantity === 1) {
-    const index = cart.indexOf(item);
-    cart.splice(index, 1);
-    dispatch(removeProduct(cart));
-  } else if (currentQuantity > 0) {
+  if (currentQuantity > 0) {
     item.quantity = currentQuantity - 1;
     dispatch(removeProduct(cart));
   }
@@ -53,8 +49,7 @@ export const removeFromCart = id => (dispatch, getState) => {
 export const eraseFromCart = id => (dispatch, getState) => {
   const cart = getState().cart.slice();
   const item = cart.find(el => el.productId === id);
-  const index = cart.indexOf(item);
-  cart.splice(index, 1);
+  item.quantity = 0;
   dispatch(eraseProduct(cart));
 };
 

--- a/server/api/carts.js
+++ b/server/api/carts.js
@@ -51,6 +51,9 @@ router.put('/', async (req, res, next) => {
         }).then(response => {
           if (response) {
             // if instance already exists
+            if (!product.quantity) {
+              return response.destroy();
+            }
             if (product.orderId) {
               // if submitting an order
               return response.update({


### PR DESCRIPTION
edited cart thunks to keep products of quantity 0 instead of deleting

edit PUT api/carts to destroy instances with with quantity 0

### Assignee Tasks

* [ ] added unit tests (or none needed)
* [ ] written relevant docs (or none needed)
* [ ] referenced any relevant issues (or none exist)

### Guidelines

Please add a description of this Pull Request's motivation, scope, outstanding issues or potential alternatives, reasoning behind the current solution, and any other relevant information for posterity.

---

_Your PR Notes Here_
